### PR TITLE
chore: publish to github registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@mok-labs:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/mok-labs/locales-check.git"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "keywords": [
     "locales",
     "i18n",
@@ -31,5 +34,6 @@
     "eslint": "^9.1.1",
     "eslint-plugin-jest": "^28.5.0",
     "jest": "^29.7.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Se agrega la configuración necesaria para publicar en github registry (para que no hayan problemas teniendo `@mok-labs/dynamic-form` en github y `@mok-labs/locales-check` en npm al instalar)